### PR TITLE
Remove unnecessary underlining from St. Jerome Commentary on Ecclesiastes

### DIFF
--- a/Jerome/Commentary on Ecclesiastes.html
+++ b/Jerome/Commentary on Ecclesiastes.html
@@ -1239,7 +1239,7 @@ which we have as "to see what will be after him", Symmachus
 interprets it more clearly saying, "so that he sees those things which
 will be after these ones". 
 Therefore nothing is good in life, unless a man is happy in his work,
-doing acts of sympathy<u>, and obtaining his future reward in the realm of
+doing acts of sympathy, and obtaining his future reward in the realm of
 heaven. We have this one lot, which nor
 neither thief nor robber values, nor any tyrant has the power to take away, and
 which follows us after our death. And we


### PR DESCRIPTION
Extremely minor but I just printed off Jerome's [Commentary on Ecclesiastes](https://historicalchristian.faith/by_father.php?file=Jerome%2FCommentary%2520on%2520Ecclesiastes.html) and noticed that Chapter 4 and everything following is underlined...  My poor toner!